### PR TITLE
Certificate issues using wget with ftp.gnu.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM gcc:9.2.0 as builder
 # Install build dependencies
 RUN ["bash", "-c", "\
   apt-get update && apt-get install -y --no-install-recommends \
-    wget \
+    curl \
     unzip \
 "]
 
@@ -20,9 +20,9 @@ WORKDIR /usr/local/lib
 
 # Download and extract GCC source tree
 RUN ["bash", "-c", "\
-  wget https://ftp.gnu.org/gnu/gcc/gcc-9.2.0/gcc-9.2.0.tar.gz \
-  && wget https://ftp.gnu.org/gnu/binutils/binutils-2.33.1.tar.gz \
-  && wget ftp://sourceware.org/pub/newlib/newlib-3.1.0.tar.gz \
+  curl -L -O https://ftp.gnu.org/gnu/gcc/gcc-9.2.0/gcc-9.2.0.tar.gz \
+  && curl -L -O https://ftp.gnu.org/gnu/binutils/binutils-2.33.1.tar.gz \
+  && curl -L -O ftp://sourceware.org/pub/newlib/newlib-3.1.0.tar.gz \
   && tar -zxf gcc-9.2.0.tar.gz \
   && tar -zxf binutils-2.33.1.tar.gz \
   && tar -zxf newlib-3.1.0.tar.gz \
@@ -53,7 +53,7 @@ RUN ["bash", "-c", "\
 
 # Download, extract, and compile bin2load
 RUN ["bash", "-c", "\
-  wget https://github.com/jguillaumes/retroutils/archive/cd2ecbd096c2c59829000fdabd51bc5284f007f8.zip \
+  curl -L -O https://github.com/jguillaumes/retroutils/archive/cd2ecbd096c2c59829000fdabd51bc5284f007f8.zip \
   && unzip cd2ecbd096c2c59829000fdabd51bc5284f007f8.zip \
   && pushd retroutils-cd2ecbd096c2c59829000fdabd51bc5284f007f8/bin2load/ \
   && make \


### PR DESCRIPTION
When building an image, ran across this issue:
```#0 0.121 --2022-11-12 16:56:50--  https://ftp.gnu.org/gnu/gcc/gcc-9.2.0/gcc-9.2.0.tar.gz
#0 0.133 Resolving ftp.gnu.org (ftp.gnu.org)... 209.51.188.20, 2001:470:142:3::b
#0 0.142 Connecting to ftp.gnu.org (ftp.gnu.org)|209.51.188.20|:443... connected.
#0 0.279 ERROR: The certificate of 'ftp.gnu.org' is not trusted.
#0 0.279 ERROR: The certificate of 'ftp.gnu.org' has expired.
```
Some research shows that `wget` has some issues with Let's Encrypt R3 CA certificate, which appears to be a bug in `wget`. 

Solution: Use `curl` instead